### PR TITLE
Migration to TestNG to fix screenshot generation before cleanup

### DIFF
--- a/atsd_webtests/pom.xml
+++ b/atsd_webtests/pom.xml
@@ -17,7 +17,7 @@
 
         <dependency>
             <groupId>io.qameta.allure</groupId>
-            <artifactId>allure-junit4</artifactId>
+            <artifactId>allure-testng</artifactId>
             <version>2.11.0</version>
             <scope>test</scope>
         </dependency>
@@ -30,9 +30,9 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.14.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/atsd_webtests/src/test/java/com/axibase/webtest/CommonAssertions.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/CommonAssertions.java
@@ -7,7 +7,7 @@ import java.time.Duration;
 import static com.axibase.webtest.PageUtils.urlPath;
 import static com.axibase.webtest.service.AtsdTest.generateAssertMessage;
 import static com.codeborne.selenide.Selenide.*;
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 public class CommonAssertions {
 

--- a/atsd_webtests/src/test/java/com/axibase/webtest/cases/CreateEntityAndMetricTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/cases/CreateEntityAndMetricTest.java
@@ -2,12 +2,13 @@ package com.axibase.webtest.cases;
 
 import com.axibase.webtest.CommonAssertions;
 import com.axibase.webtest.service.AtsdTest;
-import org.junit.Test;
+import org.testng.annotations.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.Selenide.*;
-import static org.junit.Assert.*;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.AssertJUnit.*;
 
 public class CreateEntityAndMetricTest extends AtsdTest {
 
@@ -35,6 +36,6 @@ public class CreateEntityAndMetricTest extends AtsdTest {
         assertEquals(generateAssertMessage("Wrong success message"), "Series inserted successfully", successMessage.getText().trim());
 
         open("/portals/series?entity=my-entity&metric=my-metric");
-        assertNotEquals(generateAssertMessage("No widgets for portal"), 0, $$(By.className("widget")).size());
+        assertNotEquals(0, $$(By.className("widget")).size(), generateAssertMessage("No widgets for portal"));
     }
 }

--- a/atsd_webtests/src/test/java/com/axibase/webtest/cases/CreatePortalTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/cases/CreatePortalTest.java
@@ -2,21 +2,20 @@ package com.axibase.webtest.cases;
 
 import com.axibase.webtest.CommonAssertions;
 import com.axibase.webtest.service.AtsdTest;
-import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static com.axibase.webtest.CommonConditions.clickable;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Selenide.*;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 public class CreatePortalTest extends AtsdTest {
 
@@ -62,7 +61,7 @@ public class CreatePortalTest extends AtsdTest {
 
         for (int i = 1; i < tabs.size(); i++) {
             driver.switchTo().window(tabs.get(i));
-            assertNotEquals(generateAssertMessage("No widgets for portal"), 0, $$(By.className("widget")).size());
+            assertNotEquals(0, $$(By.className("widget")).size(), generateAssertMessage("No widgets for portal"));
             driver.close();
         }
         driver.switchTo().window(tabs.get(0));

--- a/atsd_webtests/src/test/java/com/axibase/webtest/cases/CreateUserGroupTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/cases/CreateUserGroupTest.java
@@ -4,20 +4,22 @@ import com.axibase.webtest.CommonAssertions;
 import com.axibase.webtest.service.AccountService;
 import com.axibase.webtest.service.AtsdTest;
 import io.qameta.allure.Issue;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
-import static com.codeborne.selenide.Selenide.*;
-import static org.junit.Assert.*;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.open;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 public class CreateUserGroupTest extends AtsdTest {
     private static final String TEST_USER = "axiuser";
     private AccountService accountService;
 
-    @Before
+    @BeforeMethod
     public void setUp() {
         super.setUp();
         open("/admin/users/edit.xhtml");
@@ -25,7 +27,7 @@ public class CreateUserGroupTest extends AtsdTest {
         accountService.createUser(TEST_USER, TEST_USER);
     }
 
-    @After
+    @AfterMethod
     public void tearDown() {
         // Configure ATSD as it was before test
         open("/admin/users/edit.xhtml?user=" + TEST_USER);

--- a/atsd_webtests/src/test/java/com/axibase/webtest/forecasts/ForecastPageTestDependingOnTheData.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/forecasts/ForecastPageTestDependingOnTheData.java
@@ -18,10 +18,10 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
-import org.junit.Before;
-import org.junit.Test;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -40,7 +40,8 @@ import java.util.regex.Pattern;
 import static com.codeborne.selenide.Selenide.*;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.url;
-import static org.junit.Assert.*;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.AssertJUnit.*;
 
 public class ForecastPageTestDependingOnTheData extends AtsdTest {
     private static final String PAGE_URL = "/series/forecast";
@@ -56,7 +57,7 @@ public class ForecastPageTestDependingOnTheData extends AtsdTest {
     private long timeZoneHours = 0;
     private ForecastViewerPage forecastViewerPage;
 
-    @Before
+    @BeforeMethod
     public void setUp() {
         super.setUp();
         csvDataUploaderService = new CSVDataUploaderService();
@@ -243,7 +244,7 @@ public class ForecastPageTestDependingOnTheData extends AtsdTest {
                 .addForecastTab();
 
         String[] names = forecastViewerPage.getForecastTabNames();
-        assertNotEquals("Forecast names in tabs are equals but they shouldn't be", names[0], names[1]);
+        assertNotEquals(names[0], names[1], "Forecast names in tabs are equals but they shouldn't be");
 
         forecastViewerPage.setRegularizeOptions("SUM", "LINEAR", "10", "hour")
                 .switchForecastTab("Forecast 1");

--- a/atsd_webtests/src/test/java/com/axibase/webtest/forecasts/ForecastPageTestRegardlessOfData.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/forecasts/ForecastPageTestRegardlessOfData.java
@@ -5,14 +5,14 @@ import com.axibase.webtest.CommonAssertions;
 import com.axibase.webtest.CommonSelects;
 import com.axibase.webtest.pages.ForecastViewerPage;
 import com.axibase.webtest.service.AtsdTest;
-import org.junit.Before;
-import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import static com.codeborne.selenide.Selenide.*;
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 public class ForecastPageTestRegardlessOfData extends AtsdTest {
     private ForecastViewerPage forecastViewerPage;
@@ -20,7 +20,7 @@ public class ForecastPageTestRegardlessOfData extends AtsdTest {
             "metric=metric-for-regardless-of-data-test&" +
             "startDate=2015-03-04T14:24:40.000Z&horizonInterval=10-MINUTE&period=5-SECOND";
 
-    @Before
+    @BeforeMethod
     public void setUp() {
         super.setUp();
         loadData();

--- a/atsd_webtests/src/test/java/com/axibase/webtest/pages/ForecastViewerPage.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/pages/ForecastViewerPage.java
@@ -11,7 +11,7 @@ import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.fail;
+import static org.testng.AssertJUnit.fail;
 
 public class ForecastViewerPage {
     private WebDriver driver;

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/ActionOnTestState.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/ActionOnTestState.java
@@ -3,8 +3,9 @@ package com.axibase.webtest.service;
 import com.fasterxml.jackson.databind.util.ISO8601Utils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
 
 import java.util.Date;
 
@@ -14,26 +15,21 @@ import static com.codeborne.selenide.WebDriverRunner.hasWebDriverStarted;
 
 @Slf4j
 @RequiredArgsConstructor
-public class ActionOnTestState extends TestWatcher {
+public class ActionOnTestState implements ITestListener {
     @Override
-    protected void failed(Throwable e, Description description) {
-        String testClass = description.getTestClass().getSimpleName();
-        String method = description.getMethodName();
+    public void onTestFailure(ITestResult result) {
+        final String testClass = result.getTestClass().getRealClass().getSimpleName();
+        final String method = result.getMethod().getMethodName();
         final String fileName = screenshot(testClass + "_" + method + "_" + ISO8601Utils.format(new Date()));
         log.info("Screenshot saved to '{}'", fileName);
     }
 
     @Override
-    protected void finished(Description description) {
-        new LoginService().logout();
-    }
-
-    @Override
-    protected void starting(Description description) {
+    public void onTestStart(ITestResult result) {
         if (!hasWebDriverStarted()) {
             open("/");
         }
-        if (!CreateAdminAccountTest.class.equals(description.getTestClass())) {
+        if (!CreateAdminAccountTest.class.equals(result.getTestClass().getRealClass())) {
             createAdminUserIfItDoesNotExist();
         }
     }
@@ -46,5 +42,30 @@ public class ActionOnTestState extends TestWatcher {
             }
             new LoginService().logout();
         }
+    }
+
+    @Override
+    public void onFinish(ITestContext context) {
+        // do nothing
+    }
+
+    @Override
+    public void onTestSuccess(ITestResult result) {
+        // do nothing
+    }
+
+    @Override
+    public void onTestSkipped(ITestResult result) {
+        // do nothing
+    }
+
+    @Override
+    public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
+        // do nothing
+    }
+
+    @Override
+    public void onStart(ITestContext context) {
+        // do nothing
     }
 }

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/AdminBackupImportTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/AdminBackupImportTest.java
@@ -3,17 +3,13 @@ package com.axibase.webtest.service;
 import com.axibase.webtest.CommonActions;
 import com.axibase.webtest.CommonAssertions;
 import lombok.RequiredArgsConstructor;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Collection;
 
 import static com.axibase.webtest.service.ReplacementTableImportBase.ImportOptionAutoEnable.AUTO_ENABLE;
 import static com.axibase.webtest.service.ReplacementTableImportBase.ImportOptionAutoEnable.NO_AUTO_ENABLE;
@@ -22,52 +18,46 @@ import static com.axibase.webtest.service.ReplacementTableImportBase.ImportOptio
 import static com.codeborne.selenide.Selenide.$;
 
 @RequiredArgsConstructor
-@RunWith(value = Parameterized.class)
 public class AdminBackupImportTest extends ReplacementTableImportBase {
-
-    private final String testFile;
-
-    @Parameterized.Parameters(name = "{index} {0}")
-    public static Collection<Object[]> data() {
-        Object[][] data = new Object[][]{
+    @DataProvider(name = "files")
+    public static Object[][] data() {
+        return new Object[][]{
                 {AdminBackupImportTest.class.getResource("replacement-table" + File.separator + "xml-file.xml").getFile()},
                 {AdminBackupImportTest.class.getResource("replacement-table" + File.separator + "zip-archive.zip").getFile()},
                 {AdminBackupImportTest.class.getResource("replacement-table" + File.separator + "tar-archive.tar").getFile()},
                 {AdminBackupImportTest.class.getResource("replacement-table" + File.separator + "bz2-archive.tar.bz2").getFile()},
                 {AdminBackupImportTest.class.getResource("replacement-table" + File.separator + "gz-archive.tar.gz").getFile()}};
-
-        return Arrays.asList(data);
     }
 
-    @Before
+    @BeforeMethod
     public void setUp() {
         super.setUp();
         goToAdminImportBackupPage();
     }
 
-    @Test
-    public void testImportDataImportBackupPage() {
+    @Test(dataProvider = "files")
+    public void testImportDataImportBackupPage(String testFile) {
         sendFilesOnAdminImportBackup(testFile, NO_REPLACE_EXISTING, NO_AUTO_ENABLE);
         goToReplacementTablesPage();
         checkThatAllReplacementTablesAreShownInTheList();
     }
 
-    @Test
-    public void testImportDataImportBackupPageWithReplace() {
+    @Test(dataProvider = "files")
+    public void testImportDataImportBackupPageWithReplace(String testFile) {
         sendFilesOnAdminImportBackup(testFile, NO_REPLACE_EXISTING, NO_AUTO_ENABLE);
         sendFilesOnAdminImportBackup(testFile, REPLACE_EXISTING, NO_AUTO_ENABLE);
         goToReplacementTablesPage();
         checkThatAllReplacementTablesAreShownInTheList();
     }
 
-    @Test
-    public void testImportDataImportBackupPageWithAutoEnable() {
+    @Test(dataProvider = "files")
+    public void testImportDataImportBackupPageWithAutoEnable(String testFile) {
         sendFilesOnAdminImportBackup(testFile, NO_REPLACE_EXISTING, AUTO_ENABLE);
         goToReplacementTablesPage();
         checkThatAllReplacementTablesAreShownInTheList();
     }
 
-    @After
+    @AfterMethod
     public void cleanUp() {
         deleteReplacementTables();
     }

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/AdminServiceTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/AdminServiceTest.java
@@ -6,7 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.net.ntp.NTPUDPClient;
 import org.apache.commons.net.ntp.TimeInfo;
 import org.apache.commons.net.ntp.TimeStamp;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import java.net.InetAddress;
 import java.net.SocketException;
@@ -14,8 +14,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import static com.codeborne.selenide.Selenide.open;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.fail;
 
 @Slf4j
 public class AdminServiceTest extends AtsdTest {

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/AtsdTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/AtsdTest.java
@@ -1,23 +1,27 @@
 package com.axibase.webtest.service;
 
-import org.junit.Before;
-import org.junit.Rule;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 
 import static com.codeborne.selenide.Selenide.open;
 import static com.codeborne.selenide.Selenide.title;
 import static com.codeborne.selenide.WebDriverRunner.url;
 
+@Listeners(ActionOnTestState.class)
 public abstract class AtsdTest {
     static {
         Config.getInstance().init();
     }
 
-    @Rule
-    public final ActionOnTestState action = new ActionOnTestState();
-
-    @Before
+    @BeforeMethod
     public void setUp() {
         login();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void logout() {
+        new LoginService().logout();
     }
 
     public static String generateAssertMessage(String thread) {

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/CreateAdminAccountTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/CreateAdminAccountTest.java
@@ -3,20 +3,20 @@ package com.axibase.webtest.service;
 
 import com.axibase.webtest.CommonAssertions;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import static com.axibase.webtest.PageUtils.urlPath;
 import static com.axibase.webtest.service.AccountService.CREATE_ACCOUNT_TITLE;
 import static com.codeborne.selenide.Selenide.title;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 @Slf4j
 public class CreateAdminAccountTest extends AtsdTest {
     private AccountService accountService;
 
-    @Before
+    @BeforeMethod
     @Override
     public void setUp() {
         accountService = new AccountService();

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/DeleteAccountTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/DeleteAccountTest.java
@@ -3,10 +3,10 @@ package com.axibase.webtest.service;
 import com.axibase.webtest.CommonAssertions;
 import io.qameta.allure.Flaky;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import static com.codeborne.selenide.Selenide.open;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertTrue;
 
 @Slf4j
 public class DeleteAccountTest extends AtsdTest {

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/EntitiesServiceTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/EntitiesServiceTest.java
@@ -2,11 +2,11 @@ package com.axibase.webtest.service;
 
 
 import com.axibase.webtest.CommonAssertions;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import static com.codeborne.selenide.Selenide.open;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 public class EntitiesServiceTest extends AtsdTest {
 

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/ExportServiceTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/ExportServiceTest.java
@@ -3,7 +3,7 @@ package com.axibase.webtest.service;
 
 import com.google.common.net.UrlEscapers;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,8 +11,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static com.codeborne.selenide.Selenide.download;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Created by sild on 02.02.15.

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/LoginServiceTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/LoginServiceTest.java
@@ -1,17 +1,17 @@
 package com.axibase.webtest.service;
 
 import com.axibase.webtest.CommonAssertions;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Created by sild on 02.02.15.
  */
 public class LoginServiceTest extends AtsdTest {
-    @Before
+    @BeforeMethod
     @Override
     public void setUp() {
         // skip sign in

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/MetricsServiceTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/MetricsServiceTest.java
@@ -1,11 +1,11 @@
 package com.axibase.webtest.service;
 
 import com.axibase.webtest.CommonAssertions;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import static com.codeborne.selenide.Selenide.open;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Created by sild on 02.02.15.

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/ReplacementTableImportBase.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/ReplacementTableImportBase.java
@@ -1,5 +1,6 @@
 package com.axibase.webtest.service;
 
+import com.axibase.webtest.CommonActions;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.ElementsCollection;
 import io.qameta.allure.Step;
@@ -9,9 +10,8 @@ import org.openqa.selenium.By;
 import java.util.Arrays;
 import java.util.List;
 
-import com.axibase.webtest.CommonActions;
 import static com.codeborne.selenide.Selenide.$;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 public abstract class ReplacementTableImportBase extends AtsdTest {
     @Step

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/ReplacementTablesImportTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/ReplacementTablesImportTest.java
@@ -3,24 +3,22 @@ package com.axibase.webtest.service;
 import com.axibase.webtest.CommonActions;
 import com.axibase.webtest.CommonAssertions;
 import com.codeborne.selenide.CollectionCondition;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.openqa.selenium.By;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import java.io.File;
 
-import static com.axibase.webtest.PageUtils.urlPath;
 import static com.axibase.webtest.service.ReplacementTableImportBase.ImportOptionReplace.NO_REPLACE_EXISTING;
 import static com.axibase.webtest.service.ReplacementTableImportBase.ImportOptionReplace.REPLACE_EXISTING;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
-import static org.junit.Assert.assertEquals;
 
 public class ReplacementTablesImportTest extends ReplacementTableImportBase {
     private static final String XML_FILE = ReplacementTablesImportTest.class.getResource("replacement-table" + File.separator + "xml-file.xml").getFile();
 
-    @Before
+    @BeforeMethod
     public void setUp() {
         super.setUp();
         goToReplacementTablesImportPage();
@@ -43,7 +41,7 @@ public class ReplacementTablesImportTest extends ReplacementTableImportBase {
         checkThatAllReplacementTablesAreShownInTheList();
     }
 
-    @After
+    @AfterMethod
     public void cleanUp() {
         deleteReplacementTables();
     }

--- a/atsd_webtests/src/test/java/com/axibase/webtest/service/csv/CSVImportParserAsSeriesTest.java
+++ b/atsd_webtests/src/test/java/com/axibase/webtest/service/csv/CSVImportParserAsSeriesTest.java
@@ -4,29 +4,29 @@ import com.axibase.webtest.CommonActions;
 import com.axibase.webtest.CommonAssertions;
 import com.axibase.webtest.service.AtsdTest;
 import com.codeborne.selenide.CollectionCondition;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import java.util.Optional;
 
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertTrue;
 
 public class CSVImportParserAsSeriesTest extends AtsdTest {
     private static final String PARSER_NAME = "test-atsd-import-series-parser";
     private static final String PATH_TO_PARSER = CSVImportParserAsSeriesTest.class.getResource("test-atsd-import-series-parser.xml").getFile();
 
-    @Before
+    @BeforeMethod
     public void setUp() {
         super.setUp();
         goToCSVParsersImportPage();
     }
 
-    @After
+    @AfterMethod
     public void cleanup() {
         goToCSVParsersPage();
         CommonActions.deleteAllRecords();


### PR DESCRIPTION
Fixes #32
Another global migration: left JUnit for TestNG.
Pros:
* Same framework as in API tests
* Fixed screenshot generation in classes with teardown methods
* Better support for suites

Cons:
* you will need to find-and-replace the imports in your new code again