### PR TITLE
Handle onBeforeUnload hook when logging out

### DIFF
--- a/atsd_webtests/src/main/java/com/axibase/webtest/service/LoginService.java
+++ b/atsd_webtests/src/main/java/com/axibase/webtest/service/LoginService.java
@@ -1,7 +1,13 @@
 package com.axibase.webtest.service;
 
 
+import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoAlertPresentException;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import java.time.Duration;
 
 import static com.axibase.webtest.PageUtils.urlPath;
 import static com.codeborne.selenide.Selenide.*;
@@ -25,6 +31,19 @@ public class LoginService extends Service {
 
     public boolean logout() {
         open(LOGOUT_URL);
+        handleOnBeforeUnload();
         return LOGIN_URL.equals(urlPath());
+    }
+
+    private void handleOnBeforeUnload() {
+        try {
+            Alert onBeforeUnload = Wait()
+                    .withTimeout(Duration.ofMillis(50))
+                    .pollingEvery(Duration.ofMillis(10))
+                    .until(ExpectedConditions.alertIsPresent());
+            onBeforeUnload.accept();
+        } catch (NoAlertPresentException | TimeoutException e) {
+            // It is OK, no onBeforeUnload hook is set
+        }
     }
 }


### PR DESCRIPTION
This will prevent `logout()` from failure when page requests leave confirmaton, typically after another test failure